### PR TITLE
.gitignore: add .bak and .sqlite3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,3 +172,9 @@ cython_debug/
 
 # PyPI configuration file
 .pypirc
+
+# Text backup files
+*.bak
+
+# Database
+*.sqlite3


### PR DESCRIPTION
Added rules to ignore *.bak backup files and *.sqlite3 database files from version control.